### PR TITLE
Allow for telemetry 1.0 - no actual changes from 0.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Regulator.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4 or ~> 1.0.0"},
       {:plug, "~> 1.10"},
       {:norm, "~> 0.12"},
 


### PR DESCRIPTION
telemetry 1.0 is a no op from 0.4 per [`telemetry's CHANGELOG`](https://github.com/beam-telemetry/telemetry/blob/v1.0.0/CHANGELOG.md#100)

Having this allows people to use `regulator` with `telemetry` 1.0 (which now a lot of the opentelemetry libraries, especially RC ones are now starting to use).